### PR TITLE
add starttls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ May be used standalone or with Zabbix. See example of integration in `userparame
 
 #### Usage
 
-`ssl_cert_check.sh valid|expire <hostname or IP> [port] [domain for TLS SNI] [check timeout (seconds)]`
+`ssl_cert_check.sh valid|expire <hostname or IP> [port][/[starttls protocol]] [domain for TLS SNI] [check timeout (seconds)]`
 
 * `[port]` optional, default is 443
+* `[starttls protocol]` is optional, default is "tls". See "man s_client" for supported values.
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
@@ -24,6 +25,15 @@ user@host:~$ ./ssl_cert_check.sh valid valid.example.com
 1
 
 user@host:~$ ./ssl_cert_check.sh valid imap.valid.example.com 993
+1
+
+# SMTP on port 25 reqires STARTTLS. It is necessary to specify the protocol
+# to use STARTTLS. Supported protocols depend on the openssl version used.
+# For recent openssl versions the following protocols are supported:
+#  smtp, pop3, imap, ftp, xmpp, xmpp-server, irc, postgres, mysql,
+#  lmtp, nntp, sieve, ldap
+# For more details about supported protocols refer to "man s_client"
+user@host:~$ ./ssl_cert_check.sh valid smtp.valid.example.com 25/smtp
 1
 
 user@host:~$ ./ssl_cert_check.sh valid invalid.example.com

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -15,6 +15,8 @@ Script checks SSL certificate expiration and validity for HTTPS.
 
 [port] is optional, default is 443
 
+[starttls protocol] is optional, default is "tls"
+
 [domain for TLS SNI] is optional, default is hostname
 
 [check_timeout] is optional, default is $default_check_timeout seconds.
@@ -46,8 +48,14 @@ function result() { echo "$1"; exit 0; }
 check_type="$1"
 host="$2"
 port="${3:-443}"
-domain="${4:-$host}"
-check_timeout="${5:-$default_check_timeout}"
+protocol="${4:-tls}"
+domain="${5:-$host}"
+check_timeout="${6:-$default_check_timeout}"
+
+starttls=""
+if [ "$protocol" != "tls" ]; then
+	starttls="-starttls $protocol"
+fi
 
 # Check if required utilities exist
 for util in timeout openssl date; do
@@ -68,7 +76,7 @@ fi
 
 # Get certificate
 if ! output=$( echo \
-| timeout "$check_timeout" openssl s_client -servername "$domain" -verify_hostname "$domain" -connect "$host":"$port" 2>/dev/null )
+| timeout "$check_timeout" openssl s_client $starttls -servername "$domain" -verify_hostname "$domain" -connect "$host":"$port" 2>/dev/null )
 then
 	error "Failed to get certificate"
 fi

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -9,13 +9,13 @@ function show_help() {
 	# without terminal(from zabbix) this will create an unsupported item because return value is stdout + stderr
 	if [ -t 1 ]; then
 	cat >&2 << EOF
-Usage: $(basename "$0") expire|valid hostname|ip [port] [domain for TLS SNI] [check_timeout]
+Usage: $(basename "$0") expire|valid hostname|ip [port][/[starttls protocol]] [domain for TLS SNI] [check_timeout]
 
 Script checks SSL certificate expiration and validity for HTTPS.
 
 [port] is optional, default is 443
 
-[starttls protocol] is optional, default is "tls"
+[starttls protocol] is optional, default is "tls". See "man s_client" for supported values.
 
 [domain for TLS SNI] is optional, default is hostname
 
@@ -44,17 +44,25 @@ function error() { echo $error_code; echo "ERROR: $*" >&2; exit 0; }
 
 function result() { echo "$1"; exit 0; }
 
+
 # Arguments
 check_type="$1"
 host="$2"
 port="${3:-443}"
-protocol="${4:-tls}"
-domain="${5:-$host}"
-check_timeout="${6:-$default_check_timeout}"
+domain="${4:-$host}"
+check_timeout="${5:-$default_check_timeout}"
 
 starttls=""
-if [ "$protocol" != "tls" ]; then
-	starttls="-starttls $protocol"
+starttls_proto=""
+
+IFS='/' split=($port)
+
+if [ ${#split[@]} -gt 1 ]; then
+	port="${split[0]}"
+	if [ "${split[1]}" != "tls" ]; then
+		starttls="-starttls"
+		starttls_proto="${split[1]}"
+	fi
 fi
 
 # Check if required utilities exist
@@ -72,11 +80,14 @@ fi
 [ "$check_type" = "expire" ] || [ "$check_type" = "valid" ] || error "Wrong check type. Should be one of: expire,valid"
 [[ "$port" =~ ^[0-9]+$ ]] || error "Port should be a number"
 { [ "$port" -ge 1 ] && [ "$port" -le 65535 ]; } || error "Port should be between 1 and 65535"
+if [ ! -z "$starttls_proto" ]; then
+	[[ "$starttls_proto" =~ ^[a-z0-9]+$ ]] || error "Starttls protocol should be an identifier"
+fi
 [[ "$check_timeout" =~ ^[0-9]+$ ]] || error "Check timeout should be a number"
 
 # Get certificate
 if ! output=$( echo \
-| timeout "$check_timeout" openssl s_client $starttls -servername "$domain" -verify_hostname "$domain" -connect "$host":"$port" 2>/dev/null )
+| timeout "$check_timeout" openssl s_client $starttls $starttls_proto -servername "$domain" -verify_hostname "$domain" -connect "$host":"$port" 2>/dev/null )
 then
 	error "Failed to get certificate"
 fi

--- a/userparameters_ssl_cert_check.conf
+++ b/userparameters_ssl_cert_check.conf
@@ -1,4 +1,4 @@
 # Parameters:
-# <hostname or IP> [port] [domain for TLS SNI] [check timeout]
+# <hostname or IP> [port][/[protocol]] [domain for TLS SNI] [check timeout]
 UserParameter=ssl_cert_check_valid[*], /etc/zabbix/ssl_cert_check.sh valid "$1" "$2" "$3" "$4"
 UserParameter=ssl_cert_check_expire[*], /etc/zabbix/ssl_cert_check.sh expire "$1" "$2" "$3" "$4"


### PR DESCRIPTION
This PR adds support for checking certificates when servers require starttls. This is already supported in openssl for the following protocols:  "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server", "irc", "postgres", "mysql", "lmtp", "nntp", "sieve", "ldap"

For details have a look at: https://www.openssl.org/docs/manmaster/man1/openssl-s_client.html

Let me know if you are interested in merging it and I will update the documentation and config.