### PR TITLE
Use read -a to split STARTTLS port

### DIFF
--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -56,7 +56,7 @@ check_timeout="${5:-$default_check_timeout}"
 starttls=""
 starttls_proto=""
 
-IFS='/' split=($port)
+IFS='/' read -a split <<< $port
 
 if [ ${#split[@]} -gt 1 ]; then
 	port="${split[0]}"


### PR DESCRIPTION
I found that on `GNU bash, version 5.0.17(1)-release` the port split for STARTTLS wasn't working correctly, and I was getting the error `ERROR: Port should be a number`.

To reproduce:
```
$ IFS='/' split=("5222/xmpp"); echo ${#split[@]}; echo ${split}
1
5222 xmpp
```

This PR changes to using `read -a` to split, which produces:
```
$ IFS='/' read -a split <<< "5222/xmpp"; echo ${#split[@]}; echo ${split}
2
5222
```