### PR TITLE
Enforce a specific TLS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ user@host:~$ ./ssl_cert_check.sh valid 127.0.0.1 443 example.com
 user@host:~$ ./ssl_cert_check.sh valid 127.0.0.1 443 example.com 10
 1
 
+# Check a certificate on an endpoint only accepting TLS 1.2 without setting a TLS version, which will use TLS 1.2 automatically.
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10
+1
+
 # Check a certificate on an endpoint only accepting TLS 1.2 and use TLS 1.2, which is valid.
 user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 1.2
 1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ May be used standalone or with Zabbix. See the "Zabbix integration" section belo
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
+* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: 1, 1.1, 1.2, 1.3. See "man s_client" for supported TLS versions.
 
 #### Return values
 
@@ -64,6 +65,15 @@ user@host:~$ ./ssl_cert_check.sh valid 127.0.0.1 443 example.com
 # Check timeout is 10 seconds(default is 5)
 user@host:~$ ./ssl_cert_check.sh valid 127.0.0.1 443 example.com 10
 1
+
+# Check a certificate on an endpoint only accepting TLS 1.2 and use TLS 1.2, which is valid.
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 1.2
+1
+
+# Check a certificate on an endpoint only accepting TLS 1.2, but use TLS 1.1, which is invalid.
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 1.1
+-65535
+ERROR: Failed to get certificate
 ```
 
 #### Zabbix integration

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ May be used standalone or with Zabbix. See the "Zabbix integration" section belo
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
-* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: 1, 1.1, 1.2, 1.3. See "man s_client" for supported TLS versions.
+* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: tls1, tls1_1, tls1_2, tls1_3 and so on. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use `man s_client` for supported TLS options.
 
 #### Return values
 
@@ -71,11 +71,11 @@ user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.
 1
 
 # Check a certificate on an endpoint only accepting TLS 1.2 and use TLS 1.2, which is valid.
-user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 1.2
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 tls1_2
 1
 
 # Check a certificate on an endpoint only accepting TLS 1.2, but use TLS 1.1, which is invalid.
-user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 1.1
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 tls1_1
 -65535
 ERROR: Failed to get certificate
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ May be used standalone or with Zabbix. See the "Zabbix integration" section belo
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
-* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: tls1, tls1_1, tls1_2, tls1_3 and so on. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use `man s_client` for supported TLS options.
+* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: tls1, tls1_1, tls1_2, tls1_3, no_tls_1 and so on. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use `man s_client` for supported TLS options.
 
 #### Return values
 
@@ -76,6 +76,15 @@ user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.
 
 # Check a certificate on an endpoint only accepting TLS 1.2, but use TLS 1.1, which is invalid.
 user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 tls1_1
+-65535
+ERROR: Failed to get certificate
+
+# Check a certificate on an endpoint only accepting TLS 1.2, and do not use TLS 1.1, which is valid.
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 no_tls1_1
+1
+
+# Check a certificate on an endpoint only accepting TLS 1.2, and do not use TLS 1.2, which is invalid.
+user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 no_tls1_2
 -65535
 ERROR: Failed to get certificate
 ```

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -97,7 +97,7 @@ if type idn > /dev/null 2>&1; then
 fi
 
 # Verify if a TLS (or very old SSL) version is set, to append it a dash.
-if [[ ! -z "$tls_version" && (("$tls_version" == *"tls"* || "$tls_version" == *"ssl"*)) ]]; then
+if [[ ! -z "$tls_version" && (("$tls_version" == *"tls"* || "$tls_version" == *"ssl"* || "$tls_version" == *"dtls"*)) ]]; then
 	tls_version="-${tls_version}"
 else
 	tls_version=""

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -22,7 +22,7 @@ Script checks SSL certificate expiration and validity for HTTPS.
 
 [check_timeout] is optional, default is $default_check_timeout seconds
 
-[tls_version] is optional, no default is set. This will auto negotiate the TLS protocol and choose the TLS version itself. Override the TLS version as you need: 1, 1.1, 1.2, 1.3. See "man s_client" for supported TLS versions.
+[tls_version] is optional, no default is set. This will auto negotiate the TLS protocol and choose the TLS version itself. Override the TLS version as you need: tls1, tls1_1, tls1_2, tls1_3. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use `man s_client` for supported TLS options.
 
 Output:
 
@@ -96,9 +96,11 @@ if type idn > /dev/null 2>&1; then
 	domain="$(echo 	"${domain}" | idn 2>/dev/null || echo "${domain}"	)"
 fi
 
-# Verify if a TLS version is set, to append it with the TLS argument. Replace the dot with an underscore (e.g.: 1.2 -> 1_2). Going from '1.2' to '-tls1_2'
-if [ ! -z "$tls_version" ]; then
-        tls_version="-tls${tls_version/./_}"
+# Verify if a TLS (or very old SSL) version is set, to append it a dash.
+if [[ ! -z "$tls_version" && (("$tls_version" == *"tls"* || "$tls_version" == *"ssl"*)) ]]; then
+	tls_version="-${tls_version}"
+else
+	tls_version=""
 fi
 
 # Get certificate

--- a/userparameters_ssl_cert_check.conf
+++ b/userparameters_ssl_cert_check.conf
@@ -1,4 +1,4 @@
 # Parameters:
-# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout]
-UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4"
-UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4"
+# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version]
+UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"


### PR DESCRIPTION
This PR adds the possibility to use a very specific TLS version instead of using the auto negotiation that normally happens.

The way this feature is implemented should not break any existing parameters and will need all parameters set if the TLS version is required to be set.

Documentation is updated as required.

Please let me know if any changes need to be made.