### PR TITLE
Summarised JSON output + Self Signed certificates are valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ user@host:~$ ./ssl_cert_check.sh json google.com
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
-* `[tls_version,[self_signed_ok]]` = predefined options, optional.
+* `[tls_version,[self_signed_ok]]` predefined options comma (`,`) separated, flag is optional. Set what is needed, no order of parameters is present of the available options below.
 	* `[tls_version]` if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: `tls1_2`, `tls1_3`, `no_tls1`, `dtls` and so on. See the "TLS Version Options" section of [man openssl](https://www.openssl.org/docs/man3.0/man1/openssl.html) or [man s_client](https://www.openssl.org/docs/man3.0/man1/s_client.html) for the available options.
 	* `[self_signed_ok]` is optional. When this flag is set all self-signed certificates will be seen as valid. Otherwise these will be rendered invalid. It will allow OpenSSL return codes `18` and `19`. See the `Diagnostics` section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
 * `[ s_client_option1 ] [ ... ] [ s_client_optionN ]` is optional. But all other parameters are required to be set. Everything you append after all parameters will be added/appended on the OpenSSL s_client command. See all s_client options at https://www.openssl.org/docs/man1.0.2/man1/s_client.html.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.
 user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 tls1_1
 -65535
 ERROR: Failed to get certificate
+
+# Check a self-signed certificate endpoint using TLS 1.2, without assuming self-signed is valid.
+user@host:~$ ./ssl_cert_check.sh json self-signed.badssl.com 443 self-signed.badssl.com 10 tls1_2
+{"expire_days": 708, "valid": 0, "return_code": 18, "return_text": "self signed certificate"}
+
+# Check a self-signed certificate endpoint using TLS 1.2, with assuming self-signed is valid.
+user@host:~$ ./ssl_cert_check.sh json self-signed.badssl.com 443 self-signed.badssl.com 10 tls1_2,self_signed_ok
+{"expire_days": 708, "valid": 1, "return_code": 18, "return_text": "self signed certificate"}
+
 ```
 
 #### Zabbix integration

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ user@host:~$ ./ssl_cert_check.sh valid google.com
 user@host:~$ ./ssl_cert_check.sh expire 74.125.131.138 443 google.com 15 tls1_2
 56
 
+# JSON output of the certificate
+user@host:~$ ./ssl_cert_check.sh json google.com
+{"expire_days": 56, "valid": 1, "return_code": 0, "return_text": "ok"}
+
 ```
 
 - [Usage](#usage)
@@ -25,7 +29,7 @@ user@host:~$ ./ssl_cert_check.sh expire 74.125.131.138 443 google.com 15 tls1_2
 
 #### Usage
 
-`ssl_cert_check.sh valid|expire <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout (seconds)] [tls_version]`
+`ssl_cert_check.sh valid|expire|json <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout (seconds)] [tls_version]`
 
 * `[port]` optional, default is 443
 * `[starttls protocol]` optional, use protocol-specific message to switch to TLS communication. See `man s_client` option `-starttls` for supported protocols, like `smtp`, `ftp`, `ldap`.
@@ -36,9 +40,18 @@ user@host:~$ ./ssl_cert_check.sh expire 74.125.131.138 443 google.com 15 tls1_2
 
 #### Return values
 
+##### `expire` or `valid`
 * `1|0`  for validity check: 1 - valid, 0 - invalid, expired or unavailable
 * `N`  number of days left for expiration check. Zero or negative value means certificate is expired
 * `-65535`  site was unavailable for check timeout or incorrect script parameters
+
+##### `json`: JSON output
+* JSON object with a summary of the result, which can be used by Zabbix (JSONPath)
+	* `expire_days`: the amount of days before the certificate is expired
+	* `valid`: see `valid` check
+	* `return_code`: the OpenSSL return code
+	* `return_text`: the OpenSSL return text which gives helpful insights
+* $error_code	failed to get certificate or incorrect parameters
 
 Exit code is always 0, otherwise zabbix agent fails to get the item value.
 
@@ -70,6 +83,10 @@ user@host:~$ ./ssl_cert_check.sh expire google.com
 user@host:~$ ./ssl_cert_check.sh expire expired.badssl.com
 -2606
 
+# JSON output of the certificate (can be combined with/piped to `jq`)
+user@host:~$ ./ssl_cert_check.sh json google.com
+{"expire_days": 56, "valid": 1, "return_code": 0, "return_text": "ok"}
+
 # NOTE: an error message is shown to stderr only when running on a terminal
 # Without terminal(from zabbix), only the result is printed to stdout
 user@host:~$ ./ssl_cert_check.sh expire unavailable.example.com
@@ -90,7 +107,6 @@ user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.
 user@host:~$ ./ssl_cert_check.sh valid tls-v1-2.badssl.com 1012 tls-v1-2.badssl.com 10 tls1_1
 -65535
 ERROR: Failed to get certificate
-
 ```
 
 #### Zabbix integration

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ user@host:~$ ./ssl_cert_check.sh json google.com
 
 #### Usage
 
-`ssl_cert_check.sh valid|expire|json <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout (seconds)] [tls_version]`
+`ssl_cert_check.sh valid|expire|json <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout (seconds)] [tls_version,[self_signed_ok]] [ s_client_option1 ] [ ... ] [ s_client_optionN ]`
 
 * `[port]` optional, default is 443
 * `[starttls protocol]` optional, use protocol-specific message to switch to TLS communication. See `man s_client` option `-starttls` for supported protocols, like `smtp`, `ftp`, `ldap`.
 * `[domain for TLS SNI]` optional, default is `<hostname or IP>`.  
 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)*(Server Name Indication) is used to specify certificate domain name if it differs from the hostname.*
 * `[check timeout (seconds)]` optional, default is 5 seconds
-* `[tls_version]` optional, if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: `tls1_2`, `tls1_3`, `no_tls1`, `dtls` and so on. See the "TLS Version Options" section of [man openssl](https://www.openssl.org/docs/man3.0/man1/openssl.html) or [man s_client](https://www.openssl.org/docs/man3.0/man1/s_client.html) for the available options.
+* `[tls_version,[self_signed_ok]]` = predefined options, optional.
+	* `[tls_version]` if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: `tls1_2`, `tls1_3`, `no_tls1`, `dtls` and so on. See the "TLS Version Options" section of [man openssl](https://www.openssl.org/docs/man3.0/man1/openssl.html) or [man s_client](https://www.openssl.org/docs/man3.0/man1/s_client.html) for the available options.
+	* `[self_signed_ok]` is optional. When this flag is set all self-signed certificates will be seen as valid. Otherwise these will be rendered invalid. It will allow OpenSSL return codes `18` and `19`. See the `Diagnostics` section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
+* `[ s_client_option1 ] [ ... ] [ s_client_optionN ]` is optional. But all other parameters are required to be set. Everything you append after all parameters will be added/appended on the OpenSSL s_client command. See all s_client options at https://www.openssl.org/docs/man1.0.2/man1/s_client.html.
 
 #### Return values
 

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
+# Default variables
 default_check_timeout=5
 error_code=-65535
-
 # Use this list to valide if the status code is valid.
 openssl_valid_codes=(0)
 
@@ -25,7 +25,7 @@ Script checks SSL certificate expiration and validity for HTTPS.
 
 [check_timeout] is optional, default is $default_check_timeout seconds
 
-[tls_version,[self_signed_ok]] = predefined options
+[tls_version,[self_signed_ok]] predefined options comma (`,`) separated, flag is optional. Set what is needed, no order of parameters is present of the available options below.
   * [tls_version] is optional, no default is set. This will auto negotiate the TLS protocol and choose the TLS version itself. Override the TLS version as you need: tls1, tls1_1, tls1_2, tls1_3. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use "man s_client" for supported TLS options.
 
   * [self_signed_ok] is optional. When this flag is set all self-signed certificates will be seen as 'valid'. It will allow OpenSSL return codes 18 and 19. See the 'Diagnostics' section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.

--- a/userparameters_ssl_cert_check.conf
+++ b/userparameters_ssl_cert_check.conf
@@ -2,3 +2,4 @@
 # <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version]
 UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
 UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_json[*], /usr/local/bin/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"

--- a/userparameters_ssl_cert_check.conf
+++ b/userparameters_ssl_cert_check.conf
@@ -1,5 +1,5 @@
 # Parameters:
-# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version]
+# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version] [tls_version,[self_signed_ok]]
 UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
 UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
 UserParameter=ssl_cert_check_json[*], /usr/local/bin/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"

--- a/zabbix_template_examples/advanced/userparameters_ssl_cert_check.conf
+++ b/zabbix_template_examples/advanced/userparameters_ssl_cert_check.conf
@@ -1,5 +1,6 @@
 # Parameters:
-# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout]
-UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4"
-UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4"
+# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version] [tls_version,[self_signed_ok]]
+UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_json[*], /usr/local/bin/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"
 UserParameter=ssl_cert_list[*],/bin/cat /etc/zabbix/scripts/ssl_cert_list

--- a/zabbix_template_examples/basic/userparameters_ssl_cert_check.conf
+++ b/zabbix_template_examples/basic/userparameters_ssl_cert_check.conf
@@ -1,4 +1,5 @@
 # Parameters:
-# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout]
-UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4"
-UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4"
+# <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version] [tls_version,[self_signed_ok]]
+UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_json[*], /usr/local/bin/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"


### PR DESCRIPTION
This PR involves two changes, one of them is done for now:
1. Return a summarised JSON output of validity days, valid (1/0) and extra return information of OpenSSL
2. Set a flag to allow a 'self signed certificate' to be marked as valid.

Let me elaborate on the use cases.

## Summarised JSON output
This makes it very easily to have one command and have all the available data in one overview and structured in a JSON object.

Example:
```
user@host:~$ ./ssl_cert_check.sh json google.com  | jq
{
  "expire_days": 56,
  "valid": 1,
  "return_code": 0,
  "return_text": "ok"
}
```

It reduces the amount of system calls from 2 (or more if I want to have extra data) to 1 on the system. Taking into account that we can run this every X hours, it can reduce the amount of CPU power drastically.

Also extra information is embedded:
- `return_code`: 0
- `return_text`: "ok"

The return code is the same code where logic is applied to be 'valid' (= 1) or 'invalid' (= 0):
```
    Verify return code: 0 (ok)
```

The text is also extracted from the same line. Due to the clarity of the return text, we have a huge advantage of also sending this to Zabbix. It gives engineers working on the problem immediately more information on what OpenSSL has returned.

## Self signed certificates are valid
Not everyone wants this, I do agree on this. However, the validity check entitles a lot more than just verifying if it is a self signed certificate (e.g.: is it revoked, is it expired, is it 'broken'/not working, ...).

We do have lots of certificates running in our environment (of customers) and we're running this SSL script as an ExternalScript from our proxy. Because of that we do not have all the CA certificates of Self Signed certificates.

Even though, if we actually had the Self Signed CAs imported on the servers the current behaviour of the script would return that a self signed certificate is invalid, as the return code is 19:
```
    Verify return code: 19 (self signed certificate in certificate chain)
```

With the current logic applied, having the CA applied to the system would render a self signed certificate everytime invalid (as only a `0` as `Verify return code` is seen as valid).

Because we do not want that, I want to extend this PR with an extra argument that excludes some of the OpenSSL response codes. To be exact, I'd like to have the argument to allow code '18' and '19' (source: https://www.spiderbird.com/2015/08/02/openssl-s_client-to-verify-you-installed-your-certificate-properly-and-list-of-return-codes/) be seen as a valid certificate.


Upon approval of the second adjustment. I'll start with it by creating the change, I have two possible ways:
1. Have a list (comma separated) of all OpenSSL codes that should be rendered valid (where 0 is always valid). Then we can pass along `18,19` and that should work. This is **very generic** and would work for other use cases as well.
2. A flag at the end of the arguments that is `true` or `false` stating that 'self signed certificates' are valid. Then in the code enforcing that 18/19 is valid, **if this extra argument is true**.
3. Hard coded that self signed certificates **are always valid** (without an extra argument), by checking for return code `0`, `18` or `19`.

Please let me know what you prefer and/or if you have any other insights.