### PR TITLE
Append OpenSSL status code 20 & 21 as valid self signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ user@host:~$ ./ssl_cert_check.sh json google.com
 * `[check timeout (seconds)]` optional, default is 5 seconds
 * `[tls_version|tls_auto,[self_signed_ok]]` predefined options comma (`,`) separated, flag is optional. Set what is needed, no order of parameters is present of the available options below.
 	* `[tls_version]` if it is not given a TLS version will be negotiated. Override the TLS version as you need, like: `tls1_2`, `tls1_3`, `no_tls1`, `dtls` and so on. See the "TLS Version Options" section of [man openssl](https://www.openssl.org/docs/man3.0/man1/openssl.html) or [man s_client](https://www.openssl.org/docs/man3.0/man1/s_client.html) for the available options.
-	* `[self_signed_ok]` is optional. When this flag is set all self-signed certificates will be seen as valid. Otherwise these will be rendered invalid. It will allow OpenSSL return codes `18` and `19`. See the `Diagnostics` section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
+	* `[self_signed_ok]` is optional. When this flag is set all self-signed certificates will be seen as valid. Otherwise these will be rendered invalid. It will allow OpenSSL return codes `18`, `19`, `20` & `21`. See the `Diagnostics` section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
 	* [tls_auto] means auto negotiating TLS protocol. That is the default, this option is used as separator if you want to speficy additional s_client options after it.
 
 * `[ s_client_option1 ] [ ... ] [ s_client_optionN ]` is optional. But all other parameters are required to be set. Everything you append after all parameters will be added/appended on the OpenSSL s_client command. See all s_client options at https://www.openssl.org/docs/man1.0.2/man1/s_client.html.

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -147,8 +147,8 @@ tls_version=""
 for opt in "${split_options[@]}"; do
 	# Look for the flag 'self_signed_ok' to set a Self Signed certificate as valid.
 	if [ "${opt}" = "self_signed_ok" ]; then
-		# Add status codes '18' and '19' as valid in the list. See the 'Diagnostics' section at https://www.openssl.org/docs/man1.0.2/man1/verify.html
-		openssl_valid_codes+=(18 19)
+		# Add status codes '18', '19', '20' and '21' as valid in the list. See the 'Diagnostics' section at https://www.openssl.org/docs/man1.0.2/man1/verify.html
+		openssl_valid_codes+=(18 19 20 21)
 	fi
 
 	# Look for a TLS, SSL or DTLS flag and set the flag

--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -28,7 +28,7 @@ Script checks SSL certificate expiration and validity for HTTPS.
 [tls_version|tls_auto,[self_signed_ok]] predefined options comma (`,`) separated, flag is optional. Set what is needed, no order of parameters is present of the available options below.
   * [tls_version] is optional, no default is set. This will auto negotiate the TLS protocol and choose the TLS version itself. Override the TLS version as you need: tls1, tls1_1, tls1_2, tls1_3. See either the [TLS Version Options](https://www.openssl.org/docs/man3.0/man1/openssl.html) section for the TLS options or use "man s_client" for supported TLS options.
 
-  * [self_signed_ok] is optional. When this flag is set all self-signed certificates will be seen as 'valid'. It will allow OpenSSL return codes 18 and 19. See the 'Diagnostics' section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
+  * [self_signed_ok] is optional. When this flag is set all self-signed certificates will be seen as 'valid'. It will allow OpenSSL return codes 18, 19, 20 and 21. See the 'Diagnostics' section at https://www.openssl.org/docs/man1.0.2/man1/verify.html.
 
   * [tls_auto] means auto negotiating TLS protocol. That is the default, this option is used as separator if you want to speficy additional s_client options after it.
 


### PR DESCRIPTION
Initially we've only allowed 18/19 as a self signed certificate. But OpenSSL codes `20` & `21` are also used for self signed certificates according to the Diagnostics section (https://www.openssl.org/docs/man1.0.2/man1/verify.html).