### PR TITLE
Use -in /dev/stdin in openssl x509 pipe

### DIFF
--- a/ssl_cert_check.sh
+++ b/ssl_cert_check.sh
@@ -77,7 +77,7 @@ function result() { echo "$1"; exit 0; }
 
 function get_expire_days() {
 	expire_date=$( echo "$output" \
-	| openssl x509 -noout -dates \
+	| openssl x509 -noout -dates -in /dev/stdin \
 	| grep '^notAfter' | cut -d'=' -f2 )
 
 	expire_date_epoch=$($datecmd -d "$expire_date" +%s) || error "Failed to get expire date"


### PR DESCRIPTION
Otherwise openssl blurts out message to stderr "Warning: Reading certificate from stdin since no -in or -new option is given" which brakes use in zabbix-agent.