### PR TITLE
Updated templates to fix issue with Unsupported Key Item error

### DIFF
--- a/zabbix_integration_examples/README.md
+++ b/zabbix_integration_examples/README.md
@@ -1,5 +1,5 @@
 * `template_ssl_basic.xml` - basic template and userparameters for monitoring of one SSL cert per host
-  * copy `userparameters_ssl_cert_check.conf file` into `/etc/zabbix/zabbix_agentd.d` on host
+  * copy `ssl_cert_check.sh` and `userparameters_ssl_cert_check.conf file` into `/etc/zabbix/zabbix_agentd.d` on host
   * import template in zabbix server, assign to host
   * fill macroses for that host:
 	* `{$IPADDR}`
@@ -12,4 +12,5 @@
 * `template_ssl_advanced.xml` - advanced template and userparameters for monitoring of multiple ssl certs per host
   * copy `userparameters_ssl_cert_check.conf` and `userparameters_ssl_cert_discovery.conf` files into `/etc/zabbix/zabbix_agentd.d`
   * copy `ssl_cert_list.json` into `/etc/zabbix/zabbix_agentd.d` and modify to monitor your hosts. Parameter names are self-descriptive.
+  * copy `ssl_cert_check.sh` into `/etc/zabbix/zabbix_agentd.d`
   * import template in zabbix server, assign to host, wait for auto discovery

--- a/zabbix_integration_examples/userparameters_ssl_cert_check.conf
+++ b/zabbix_integration_examples/userparameters_ssl_cert_check.conf
@@ -1,5 +1,5 @@
 # Parameters:
 # <hostname or IP> [port[/starttls protocol]] [domain for TLS SNI] [check timeout] [tls version] [tls_version,[self_signed_ok]]
-UserParameter=ssl_cert_check_valid[*], /usr/local/bin/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
-UserParameter=ssl_cert_check_expire[*], /usr/local/bin/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
-UserParameter=ssl_cert_check_json[*], /usr/local/bin/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_valid[*], /etc/zabbix/zabbix_agentd.d/ssl_cert_check.sh valid "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_expire[*], /etc/zabbix/zabbix_agentd.d/ssl_cert_check.sh expire "$1" "$2" "$3" "$4" "$5"
+UserParameter=ssl_cert_check_json[*], /etc/zabbix/zabbix_agentd.d/ssl_cert_check.sh json "$1" "$2" "$3" "$4" "$5"


### PR DESCRIPTION
Current template causes Unsupported Key Item error when following README instructions. I've updated the file locations recommended to match resolutions in several issue threads.